### PR TITLE
Fix #46: Help requests cannot be created

### DIFF
--- a/src/pages/GetHelp.vue
+++ b/src/pages/GetHelp.vue
@@ -30,7 +30,7 @@
       <q-input
         dense filled
         v-model="enddate"
-        mask="##/##/####"
+        mask="##.##.####"
         label="Bis"
         class="input"
         :rules="['date']">
@@ -185,6 +185,7 @@ export default {
           throw new Error('Some fields are empty.')
         }
 
+        const [day, month, year] = this.enddate.split('.')
         const res = await callApi(
           this.$q.localStorage.getItem('server') + 'request',
           this.auth.token,
@@ -196,7 +197,7 @@ export default {
             'address.city': this.city,
             'address.street': this.street,
             'address.street_nr': this.streetNumber,
-            time_end: this.enddate
+            time_end: month + '/' + day + '/' + year
           },
           'POST'
         )
@@ -206,7 +207,6 @@ export default {
         }
 
         this.loading = false
-        history.push('/profile/search')
       } catch (e) {
         console.error(e)
         this.loading = false

--- a/src/pages/GetHelp.vue
+++ b/src/pages/GetHelp.vue
@@ -207,6 +207,7 @@ export default {
         }
 
         this.loading = false
+        this.$router.push('/')
       } catch (e) {
         console.error(e)
         this.loading = false

--- a/src/pages/GetHelp.vue
+++ b/src/pages/GetHelp.vue
@@ -30,10 +30,8 @@
       <q-input
         dense filled
         v-model="enddate"
-        mask="##.##.####"
         label="Bis"
-        class="input"
-        :rules="['date']">
+        class="input">
         <template v-slot:append>
           <q-icon name="event" class="cursor-pointer">
             <q-popup-proxy ref="qDateProxy" transition-show="scale" transition-hide="scale">
@@ -41,7 +39,7 @@
                 first-day-of-week="1"
                 v-model="enddate"
                 @input="() => $refs.qDateProxy.hide()"
-                mask="DD-MM-YYYY"></q-date>
+                mask="DD.MM.YYYY"></q-date>
             </q-popup-proxy>
           </q-icon>
         </template>


### PR DESCRIPTION
#46
Help requests can now be sent to the backend.
**Important:** The city has to be an actual city. Otherwise, the backend will return `500: Google API fail`