### PR TITLE
Fix broken routing

### DIFF
--- a/src/components/Offer.vue
+++ b/src/components/Offer.vue
@@ -7,11 +7,10 @@
         <p>Du wirst bestimmt bald kontaktiert!</p>
         <q-btn
           rounded
-          to="/"
+          to="/profile/requests"
           color="secondary"
           label="Anfragen zeigen"
           style="width: 100%"></q-btn>
-      <!--TODO: redirect to /profile/requests once this page exists -->
     </q-card>
 
 <!--    <q-card-->
@@ -24,7 +23,7 @@
 <!--      <q-card-actions align="center">-->
 <!--        <q-btn-->
 <!--          rounded-->
-<!--          to="login"-->
+<!--          to="/login"-->
 <!--          color="secondary"-->
 <!--          label="Zum Login"-->
 <!--          style="width: 100%"></q-btn>-->

--- a/src/components/ProfileButton.vue
+++ b/src/components/ProfileButton.vue
@@ -115,7 +115,7 @@ export default {
         authenticated: false
       }
       this.$q.sessionStorage.clear()
-      this.$router.push('login')
+      this.$router.push('/login')
     }
   }
 }

--- a/src/pages/GetHelp.vue
+++ b/src/pages/GetHelp.vue
@@ -151,7 +151,7 @@ export default {
     if (this.auth.authenticated) {
       this.loadCategories()
     } else {
-      this.$router.push('login')
+      this.$router.push('/login')
     }
   },
 
@@ -210,7 +210,7 @@ export default {
         }
 
         this.loading = false
-        this.$router.push('profile/requests')
+        this.$router.push('/profile/requests')
       } catch (e) {
         this.loading = false
         this.error = e

--- a/src/pages/Help.vue
+++ b/src/pages/Help.vue
@@ -128,7 +128,7 @@ export default {
     if (this.auth.authenticated) {
       this.fetchRequests()
     } else {
-      this.$router.push('login')
+      this.$router.push('/login')
     }
   },
 

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -21,7 +21,7 @@
             <q-btn
               rounded
               label="Registrieren"
-              @click="$router.push('/register')"
+              to="/register"
             />
           </form>
         </div>

--- a/src/pages/MyRequests.vue
+++ b/src/pages/MyRequests.vue
@@ -109,7 +109,7 @@ export default {
 
   mounted () {
     if (!this.auth.authenticated) {
-      this.$router.push('login')
+      this.$router.push('/login')
     }
     this.fetchRequests()
   },


### PR DESCRIPTION
From `/profile/requests`, `'/login'` goes to the login page while `'login'` goes to `/profile/login`, which does not exist.