### PR TITLE
Replace !important with more specific selectors

### DIFF
--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -35,8 +35,8 @@ strong
   color: $secondary
 
 button, a[type=button]
-  color: white !important
-  background-color: $secondary !important
+  color: white
+  background-color: $secondary
   border: 0
   border-radius: 19px
   cursor: pointer
@@ -57,6 +57,9 @@ button, a[type=button]
     font-weight: 600
     margin-top: 15px
 
+.q-btn
+  color: white
+  background-color: $secondary
 a
   text-decoration: none
 

--- a/src/pages/GetHelp.vue
+++ b/src/pages/GetHelp.vue
@@ -96,22 +96,25 @@
 </template>
 
 <style lang="sass" scoped>
-  h3:first-of-type
-    margin: 0 0 5px
+h3:first-of-type
+  margin: 0 0 5px
 
-  h3
-    margin: 20px 0 0
+h3
+  margin: 20px 0 0
 
-  .input
-    margin: 5px 0
+.input
+  margin: 5px 0
 
-  .error
-    background: RED
-    color: WHITE
-    padding: 10px 25px
-    margin-bottom: 15px
-    border-radius: 19px !important
-    font-size: 13px
+.error
+  background: RED
+  color: WHITE
+  padding: 10px 25px
+  margin-bottom: 15px
+  font-size: 13px
+
+.q-card
+  div
+    border-radius: 19px
 </style>
 
 <script>


### PR DESCRIPTION
You were right, @jolo-dev, it makes unnecessary trouble using `!important`. 😅 I've found an alternative way.