### PR TITLE
FE-17 Use relative URL to backend

### DIFF
--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -1,3 +1,4 @@
 {
-  "url": "https://dev.coronahelfer.eu/api/v1/"
+  "use-external-backend": false,
+  "url": "https://dev.coronahelfer.eu"
 }

--- a/src/components/Offer.vue
+++ b/src/components/Offer.vue
@@ -94,7 +94,7 @@ export default {
         if (this.offer === '') throw new Error(this.$t('emptyField'))
 
         const res = await callApi(
-          this.$q.localStorage.getItem('server') + '/api/v1/' + 'request/helper',
+          this.$q.localStorage.getItem('server') + '/api/v1/request/helper',
           this.auth.token,
           {
             offerText: this.offer,

--- a/src/components/Offer.vue
+++ b/src/components/Offer.vue
@@ -94,7 +94,7 @@ export default {
         if (this.offer === '') throw new Error(this.$t('emptyField'))
 
         const res = await callApi(
-          this.$q.localStorage.getItem('server') + 'request/helper',
+          this.$q.localStorage.getItem('server') + '/api/v1/' + 'request/helper',
           this.auth.token,
           {
             offerText: this.offer,

--- a/src/pages/GetHelp.vue
+++ b/src/pages/GetHelp.vue
@@ -188,7 +188,7 @@ export default {
 
         const [day, month, year] = this.enddate.split('.')
         const res = await callApi(
-          this.$q.localStorage.getItem('server') + '/api/v1/' + 'request',
+          this.$q.localStorage.getItem('server') + '/api/v1/'request',
           this.auth.token,
           {
             title: this.title,

--- a/src/pages/GetHelp.vue
+++ b/src/pages/GetHelp.vue
@@ -157,7 +157,7 @@ export default {
   methods: {
     async loadCategories () {
       try {
-        let categories = await fetch(this.$q.localStorage.getItem('server') + 'category')
+        let categories = await fetch(this.$q.localStorage.getItem('server') + '/api/v1/category')
         categories = await categories.json()
 
         if (categories.error || !categories.result) {
@@ -188,7 +188,7 @@ export default {
 
         const [day, month, year] = this.enddate.split('.')
         const res = await callApi(
-          this.$q.localStorage.getItem('server') + 'request',
+          this.$q.localStorage.getItem('server') + '/api/v1/' + 'request',
           this.auth.token,
           {
             title: this.title,

--- a/src/pages/GetHelp.vue
+++ b/src/pages/GetHelp.vue
@@ -188,7 +188,7 @@ export default {
 
         const [day, month, year] = this.enddate.split('.')
         const res = await callApi(
-          this.$q.localStorage.getItem('server') + '/api/v1/'request',
+          this.$q.localStorage.getItem('server') + '/api/v1/request',
           this.auth.token,
           {
             title: this.title,

--- a/src/pages/Help.vue
+++ b/src/pages/Help.vue
@@ -144,7 +144,7 @@ export default {
         headers.append('position', latitude)
 
         const response = await callApi(
-          this.$q.localStorage.getItem('server') + '/api/v1/' + 'publicRequest',
+          this.$q.localStorage.getItem('server') + '/api/v1/publicRequest',
           undefined,
           undefined,
           undefined,

--- a/src/pages/Help.vue
+++ b/src/pages/Help.vue
@@ -144,7 +144,7 @@ export default {
         headers.append('position', latitude)
 
         const response = await callApi(
-          this.$q.localStorage.getItem('server') + 'publicRequest',
+          this.$q.localStorage.getItem('server') + '/api/v1/' + 'publicRequest',
           undefined,
           undefined,
           undefined,

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -145,7 +145,11 @@ export default {
     if (this.$q.localStorage.getItem('server') === null) {
       // TODO: Set default values in a way that user does not have to access the landing page first
       const config = require('../assets/config.json')
-      this.$q.localStorage.set('server', config.url)
+      if (config['use-external-backend']) {
+        this.$q.localStorage.set('server', config.url)
+      } else {
+        this.$q.localStorage.set('server', '')
+      }
     }
   }
 }

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -155,7 +155,7 @@ export default {
         }
 
         await callApi(
-          this.$q.localStorage.getItem('server') + '/api/v1/' + 'users/me',
+          this.$q.localStorage.getItem('server') + '/api/v1/users/me',
           res.token
         ).then((resp) => {
           this.auth = {

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -135,7 +135,7 @@ export default {
         }
 
         let res = await fetch(
-          this.$q.localStorage.getItem('server') + 'auth/login',
+          this.$q.localStorage.getItem('server') + '/api/v1/auth/login',
           {
             method: 'post',
             headers: {
@@ -155,7 +155,7 @@ export default {
         }
 
         await callApi(
-          this.$q.localStorage.getItem('server') + 'users/me',
+          this.$q.localStorage.getItem('server') + '/api/v1/' + 'users/me',
           res.token
         ).then((resp) => {
           this.auth = {

--- a/src/pages/MyRequests.vue
+++ b/src/pages/MyRequests.vue
@@ -118,7 +118,7 @@ export default {
     async fetchRequests () {
       try {
         const result = await callApi( // TODO: deduplicate this function
-          this.$q.localStorage.getItem('server') + 'request',
+          this.$q.localStorage.getItem('server') + '/api/v1/' + 'request',
           this.auth.token
         )
         this.requests = result.result

--- a/src/pages/MyRequests.vue
+++ b/src/pages/MyRequests.vue
@@ -118,7 +118,7 @@ export default {
     async fetchRequests () {
       try {
         const result = await callApi( // TODO: deduplicate this function
-          this.$q.localStorage.getItem('server') + '/api/v1/' + 'request',
+          this.$q.localStorage.getItem('server') + '/api/v1/request',
           this.auth.token
         )
         this.requests = result.result

--- a/src/pages/Profile.vue
+++ b/src/pages/Profile.vue
@@ -198,7 +198,7 @@ export default {
   methods: {
     async fetchUserData() { // TODO: Deduplicate this request
       await callApi(
-        this.$q.localStorage.getItem('server') + 'users/me',
+        this.$q.localStorage.getItem('server') + '/api/v1/' + 'users/me',
         this.auth.token
       ).then((resp) => {
         this.auth = {

--- a/src/pages/Profile.vue
+++ b/src/pages/Profile.vue
@@ -198,7 +198,7 @@ export default {
   methods: {
     async fetchUserData() { // TODO: Deduplicate this request
       await callApi(
-        this.$q.localStorage.getItem('server') + '/api/v1/' + 'users/me',
+        this.$q.localStorage.getItem('server') + '/api/v1/users/me',
         this.auth.token
       ).then((resp) => {
         this.auth = {

--- a/src/pages/Register.vue
+++ b/src/pages/Register.vue
@@ -181,7 +181,7 @@ export default {
         }
 
         let res = await fetch(
-          this.$q.localStorage.getItem('server') + 'auth/register',
+          this.$q.localStorage.getItem('server') + '/api/v1/auth/register',
           {
             method: 'post',
             headers: {
@@ -208,7 +208,7 @@ export default {
         }
 
         await callApi(
-          this.$q.localStorage.getItem('server') + 'users/me',
+          this.$q.localStorage.getItem('server') + '/api/v1/' + 'users/me',
           res.token
         ).then(resp => {
           this.auth = {

--- a/src/pages/Register.vue
+++ b/src/pages/Register.vue
@@ -208,7 +208,7 @@ export default {
         }
 
         await callApi(
-          this.$q.localStorage.getItem('server') + '/api/v1/' + 'users/me',
+          this.$q.localStorage.getItem('server') + '/api/v1/users/me',
           res.token
         ).then(resp => {
           this.auth = {


### PR DESCRIPTION
The frontend can now connect to a backend on the same server without the need to adjust the `config.json` anymore.
If you want to connect to an external backend (e.g., for local development), set `use-external-backend` to `true` in the `config.json`.
In both cases, please clear the Local Storage in your browser and go to the main page to re-load the `config.json`.